### PR TITLE
Initialise endTime

### DIFF
--- a/src/main/java/com/mongodb/oploganalyzer/OplogAnalyzer.java
+++ b/src/main/java/com/mongodb/oploganalyzer/OplogAnalyzer.java
@@ -72,6 +72,7 @@ public class OplogAnalyzer {
         mongoClient = new MongoClient(new MongoClientURI(uri));
         this.threshold = threshold;
         this.startTime = startTime;
+        this.endTime = endTime;
     }
 
     public void process() throws InvalidFormatException, IOException {


### PR DESCRIPTION
The specified endTime was always disregarded when executing a command like "java -jar OplogAnalyzer.jar -c "$MONGO_URI" -s "2023-01-23T08:17:00.000Z" -e "2023-01-23T08:21:00.000Z". 